### PR TITLE
fix: Hover is not reset properly with touchscreens.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ qtquickcontrols2-opensource-src (5.15.7.1-1+dde) UNRELEASED; urgency=medium
 
   * QQuickControl: Palette's currentColorGroup is error
     --Fix-QQuickControl-Palette-currentColorGroup-is-error.patch
+  * Fix the abnormal state of button hover on the touch screen
+    --Fix-the-abnormal-state-of-button-hover-on-the-touch-screen.patch
 
  -- Duan Ting <duanting@uniontech.com>  Mon, 12 Dec 2022 16:09:13 +0800
 

--- a/debian/patches/Fix-the-abnormal-state-of-button-hover-on-the-touch-screen.patch
+++ b/debian/patches/Fix-the-abnormal-state-of-button-hover-on-the-touch-screen.patch
@@ -1,0 +1,36 @@
+Author: Duan Ting <duanting@uniontech.com>
+Date:   Tue Jan 3 10:50:18 2023 +0800
+Subject: Fix the abnormal state of button hover on the touch screen
+---
+
+Index: qtquickcontrols2-opensource-src/src/quicktemplates2/qquickabstractbutton.cpp
+===================================================================
+--- qtquickcontrols2-opensource-src.orig/src/quicktemplates2/qquickabstractbutton.cpp
++++ qtquickcontrols2-opensource-src/src/quicktemplates2/qquickabstractbutton.cpp
+@@ -1043,6 +1043,10 @@ bool QQuickAbstractButton::event(QEvent
+         }
+     }
+ #endif
++
++    if (event->type() == QEvent::HoverMove)
++        return true;    
++
+     return QQuickControl::event(event);
+ }
+ 
+Index: qtquickcontrols2-opensource-src/src/quicktemplates2/qquickcontrol.cpp
+===================================================================
+--- qtquickcontrols2-opensource-src.orig/src/quicktemplates2/qquickcontrol.cpp
++++ qtquickcontrols2-opensource-src/src/quicktemplates2/qquickcontrol.cpp
+@@ -2214,8 +2214,10 @@ void QQuickControl::touchEvent(QTouchEve
+             case Qt::TouchPointMoved:
+                 d->handleMove(point.pos());
+                 break;
+-            case Qt::TouchPointReleased:
++            case Qt::TouchPointReleased: {
++                setHovered(false);
+                 d->handleRelease(point.pos());
++            }
+                 break;
+             default:
+                 break;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@ disable_fontless_examples_build.patch
 QTBUG-101480-Fix-controls-not-inheriting-palette-from-parent.patch
 QTBUG-76860-QQuickPlatformFolderDialog-Allow-opening-selected-folder.patch
 Fix-QQuickControl-Palette-currentColorGroup-is-error.patch
+Fix-the-abnormal-state-of-button-hover-on-the-touch-screen.patch


### PR DESCRIPTION
When hoverEnabled:true is set, the hover state is still true when the button is released under the touch screen. So the hover state should be reset when the QEvent::TouchEnd event is detected.

In addition, long press the button under the touch screen and release it, it will trigger the QEvent::hoverMove event, which will also cause hover is true after release. Reading the QEvent::hoverMove event documentation, it doesn't make sense for Button.
Therefore, the QEvent::hoverMove event is not handled in the button.

Bug: https://pms.uniontech.com/bug-view-155535.html

log: Fix the abnormal state of button hover on the touch screen.